### PR TITLE
Refacto to use router_level

### DIFF
--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -57,11 +57,13 @@ If this new power meter needs specific configuration, required parameters have t
 
 A documentation have to be added describing the power meter and how to configure it. See [update documentation](#update-documentation) chapter bellow.
 
-### Developping a **Regulator**
+### Developping **Regulator**
 
-A **Regulator** has to manage the percentage of energy sent to the load based on the `regulator_opening` sensor state. `regulator_opening` state can vary from 0 (where no energy is sent to the load) to 100 (where all the energy possible is sent to the load).
+A **Regulator** has to manage the percentage of energy sent to its load based on its regulator level sensor (e.g., `regulator_opening` for TRIAC/SSR). Each regulator's level can vary from 0 (where no energy is sent to the load) to 100 (where all possible energy is sent to the load).
 
-The following code represent an example (extracted from [regulator_triac.yaml](https://github.com/XavierBerger/Solar-Router-for-ESPHome/blob/main/solar_router/regulator_triac.yaml)) of usage based on `light` component using `brightness` to control the energy diverted:
+The system's overall state is managed by the `router_level` sensor, which controls all regulators. When `router_level` is 0, all regulators should be off, and when it's 100, all regulators should be at maximum. For systems with a single regulator, the regulator's level typically mirrors the `router_level`, but they remain separate as `router_level` is used for LED indicators and energy counting logic.
+
+Here's an example of a regulator implementation (extracted from [regulator_triac.yaml](https://github.com/XavierBerger/Solar-Router-for-ESPHome/blob/main/solar_router/regulator_triac.yaml)) using the `light` component's `brightness` to control energy diversion:
 
 ```yaml linenums="1"
 script:
@@ -69,13 +71,18 @@ script:
   - id: regulation_control
     mode: single
     then:
-      # Apply opening level on triac using light component
+      # Apply router_level to triac using light component
       - light.turn_on:
           id: dimmer_controller
           brightness: !lambda return id(regulator_opening).state/100.0;
 ```
 
-!!! tip "Tip: See already developped regulators for examples"
+!!! tip "Tip: See already developed regulators for examples"
+
+You can develop one or multiple regulators to work together in the same system. Each regulator should:
+- Have its own level sensor ranging from 0-100
+- Respond to changes in the system-wide `router_level`
+- Handle its specific hardware control logic
 
 If this new power meter needs specific configuration, required parameters have to be added into `substitution` section.
 

--- a/docs/en/engine.md
+++ b/docs/en/engine.md
@@ -23,6 +23,18 @@ The green LED is reflecting the actual configuration of regulation:
 - ***ON*** : automatic regulation is active and is not diverting energy to the load.
 - ***blink*** : solar router is currently sending energy to the load.
 
+## Router Level vs Regulator Opening
+
+The solar router uses two distinct but related level controls:
+
+- **Router Level**: This is the main system-wide control (0-100%) that represents the overall routing state. It controls the LED indicators and energy counter logic. When automatic regulation is enabled, this level is dynamically adjusted based on power measurements.
+
+- **Regulator Opening**: This represents the actual opening level (0-100%) of the physical regulator. By default, it mirrors the router level since there is only one regulator. While it can be controlled independently, changes to regulator_opening alone won't affect the router_level or trigger LED state changes.
+
+The regulator opening entity is hidden from Home Assistant by default. To expose it, add this to your substitutions:
+
+Note: It's recommended to adjust the router_level rather than regulator_opening directly, as this ensures proper system feedback through LEDs and energy monitoring.
+
 ## Configuration
 
 To use this package, add the following lines to your configuration file:
@@ -43,4 +55,6 @@ substitutions:
   # Yellow LED is reflecting power meter status
   green_led_pin: GPIO19
   yellow_led_pin: GPIO18
+  # (Optional) Expose regulator opening to HA (hidden by default)
+  hide_regulators: "False"
 ```

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -52,7 +52,7 @@ A **proxy** just need 1 **power meter** package
 #### Step 2.3: Add an Engine
 
 * [Progressive Engine](engine.md)  
-  Read power exchange with the grid, determine and apply the percentage of regulator opening.
+  Read power exchange with the grid, determine and apply the percentage of router level.
 
 * [ON/OFF Engine](engine_on_off.md)  
   Read power exchange with the grid, and start to divert energy if a threshold is reached and stop if another threshold is reached.

--- a/docs/en/solar_router.md
+++ b/docs/en/solar_router.md
@@ -14,7 +14,8 @@
       How fast will be the solar routing
       From 1 to 100. 1 is the slowest, 100 is the fastest.
     * ***Router Level***  
-      What is the current percentage of gate opening to send energy to the load 
+      What is the current percentage of energy sent to the load by the overall router
+      From 0 to 100. 0 means no energy diverted, 100 means all energy diverted.
     * ***Target grid exchange***  
       What is the target of energy exchanged with the grid.  
       &lt; 0 energy is sent to the grid  
@@ -31,7 +32,7 @@
 
 !!! note 
     When solar routing is deactivated, router level slider can be modified "by hand".  
-    If you modify the triac opening state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.
+    If you modify the router level state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.
 
 ## ON/OFF regulation
 
@@ -41,8 +42,9 @@
     
     * ***Activate Solar Routing***  
       Control if Solar routing should be activated or not
-    * ***Energy divertion***  
-      Ectivate energy divertion or not 
+    * ***Router Level***  
+      What is the current percentage of energy sent to the load by the overall router
+      Either 0 OR 100. 0 means no energy diverted, 100 means all energy diverted.
     * ***Start power level***  
       Define the level of energy when divertion has to start  
     * ***Start tempo***  
@@ -64,7 +66,6 @@
 <br>
 <br>
 
-
 !!! note 
     When solar routing is deactivated, router level slider can be modified "by hand".  
-    If you modify the triac opening state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.
+    If you modify the router level state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.

--- a/docs/en/solar_router.md
+++ b/docs/en/solar_router.md
@@ -13,7 +13,7 @@
     * ***Reactivity***  
       How fast will be the solar routing
       From 1 to 100. 1 is the slowest, 100 is the fastest.
-    * ***Regulator opening***  
+    * ***Router Level***  
       What is the current percentage of gate opening to send energy to the load 
     * ***Target grid exchange***  
       What is the target of energy exchanged with the grid.  
@@ -30,7 +30,7 @@
 <br>  
 
 !!! note 
-    When solar routing is deactivated, regulator opening slider can be modified "by hand".  
+    When solar routing is deactivated, router level slider can be modified "by hand".  
     If you modify the triac opening state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.
 
 ## ON/OFF regulation
@@ -66,5 +66,5 @@
 
 
 !!! note 
-    When solar routing is deactivated, regulator opening slider can be modified "by hand".  
+    When solar routing is deactivated, router level slider can be modified "by hand".  
     If you modify the triac opening state while the solar routing is enabled, the routing algorithm will immediately modify the value to meet target grid exchange level.

--- a/docs/fr/contributing.md
+++ b/docs/fr/contributing.md
@@ -1,75 +1,77 @@
 # Contribuer au développement
 
-**Solar Router for [ESPHome](http://esphome.io)** est conçu pour être modulaire afin de faciliter la personnalisation pour divers compteurs d'énergie et régulateurs.  
-Vous souhaitez contribuer ? Vous êtes le bienvenu et vous trouverez ci-dessous quelques recommandations pour le faire.
+**Solar Router pour [ESPHome](http://esphome.io)** est conçu de manière modulaire pour faciliter la personnalisation avec différents compteurs de puissance et différents régulateurs.  
+Vous souhaitez contribuer ? Vous êtes les bienvenus et vous trouverez ci-dessous quelques recommandations pour le faire.
 
-## Développer un **Matériel**
+## Développer un **Hardware**
 
-Vous pouvez proposer n'importe quel matériel basé sur vos besoins. Si ce nouveau matériel nécessite l'utilisation de GPIO, les broches utilisées par votre matériel doivent être configurées dans la section `substitution`.
+Vous pouvez proposer n'importe quel matériel selon vos besoins. Si ce nouveau matériel nécessite l'utilisation de GPIO, les broches utilisées par votre matériel doivent être configurées dans la section `substitution`.
 
-Une documentation doit être ajoutée décrivant ce nouveau matériel et ses contraintes (Ex : fonctionnalité disponibles sur les GPIO). Voir le chapitre [mettre à jour la documentation](#mise-a-jour-de-la-documentation) ci-dessous.
+Une documentation doit être ajoutée décrivant ce nouveau matériel et ses contraintes (Ex : capacités GPIO). Voir le chapitre [mettre à jour la documentation](#mettre-à-jour-la-documentation) ci-dessous.
 
-## Développer un **Package logiciel**
+## Développer un **Package Logiciel**
 
 ### Configurer l'environnement de développement
 
-Pour contribuer à **Solar Router for ESPHome**, développer une nouvelle fonctionnalité sur votre ordinateur et proposer une *Pull Request*, vous devez :
+Pour contribuer à **Solar Router pour ESPHome**, développer une nouvelle fonctionnalité sur votre ordinateur et proposer une *demande de fusion*, vous devez :
 
-- Forker le [dépôt **Solar Router for ESPHome**](https://github.com/XavierBerger/Solar-Router-for-ESPHome) sur Github.
-- Cloner votre dépôt forké sur votre PC.
-- Créer une branche de développement à partir de **main**.
-- [Créer et activer un environnement virtuel Python](https://docs.python.org/3/library/venv.html) :
-    ```
+- Forker le [dépôt **Solar Router pour ESPHome**](https://github.com/XavierBerger/Solar-Router-for-ESPHome) sur Github
+- Cloner votre dépôt forké sur votre PC
+- Créer une branche de développement à partir de **main**
+- [Créer et activer un environnement virtuel Python](https://docs.python.org/3/library/venv.html)
+    ```shell
     python -m venv venv
     venv/bin/activate
     ```
-- Installer ESPHome CLI et autres dépendances du projet :
-    ```
+- Installer ESPHome CLI et autres dépendances :
+    ```shell
     pip install -r requirements.txt
-    ``` 
-- Installer et tester votre code sur votre appareil avec la commande `esphome` : 
     ```
-    esphome run ma_configuration.yaml
+- Installer et tester votre code sur votre appareil avec la commande `esphome` :
+    ```shell
+    esphome run my_configuration.yaml
     ```
-- Mettre à jour le code et pousser les mises à jour sur votre dépôt.
-- Proposer une *Pull Request* depuis votre fork vers le dépôt officiel.
+- Mettre à jour le code et pousser les modifications sur votre dépôt
+- Proposer une pull request depuis votre fork vers le dépôt officiel
 
-### Développer un **Power Meter**
+### Développer un **Compteur de Puissance**
 
-Un **Power Meter** est un composant conçu pour fournir et mettre à jour un sensor nommé `real_power`.
+Un **Compteur de Puissance** est un composant conçu pour fournir et mettre à jour périodiquement un capteur nommé `real_power`.
 
 ```yaml linenums="1"
 sensor:
-  # Sensor showing the actual power consumption
+  # Capteur montrant la consommation de puissance actuelle
   - id: real_power
     platform: template
-    name: "Real Power"
+    name: "Puissance Réelle"
     device_class: "power"
     unit_of_measurement: "W"
     update_interval: 1s
 ```
 
-!!! tip "Astuce : Voir les Power Meter déjà développés pour des exemples"
+!!! tip "Astuce : Voir les compteurs de puissance déjà développés pour des exemples"
 
-Ce capteur est utilisé par les **Engine** pour obtenir la valeur de la puissance échangée avec le réseau.
+Ce capteur est utilisé par les **Moteurs** pour obtenir la valeur de la puissance échangée avec le réseau.
 
-Si ce nouveau Power Meter nécessite une configuration spécifique, les paramètres requis doivent être ajoutés dans la section `substitution`.
+Si ce nouveau compteur de puissance nécessite une configuration spécifique, les paramètres requis doivent être ajoutés dans la section `substitution`.
 
-Une documentation doit être ajoutée décrivant le Power Meter et comment le configurer. Voir le chapitre [mettre à jour la documentation](#mise-a-jour-de-la-documentation) ci-dessous.
+Une documentation doit être ajoutée décrivant le compteur de puissance et comment le configurer. Voir le chapitre [mettre à jour la documentation](#mettre-à-jour-la-documentation) ci-dessous.
 
-### Développer un **Régulateur**
+### Développer des **Régulateurs**
 
-Un **Régulateur** doit gérer le pourcentage d'énergie envoyé à la charge en fonction de l'état du capteur `regulator_opening`. L'état de `regulator_opening` peut varier de 0 (où aucune énergie n'est envoyée à la charge) à 100 (où toute l'énergie possible est envoyée à la charge).
+Un **Régulateur** doit gérer le pourcentage d'énergie envoyé à sa charge en fonction de son capteur de niveau de régulation (par exemple, `regulator_opening` pour TRIAC/SSR). Le niveau de chaque régulateur peut varier de 0 (où aucune énergie n'est envoyée à la charge) à 100 (où toute l'énergie possible est envoyée à la charge).
 
-Le code suivant représente un exemple (extrait de [regulator_triac.yaml](https://github.com/XavierBerger/Solar-Router-for-ESPHome/blob/main/solar_router/regulator_triac.yaml)) d'utilisation basé sur le composant `light` utilisant `brightness` pour contrôler l'énergie dérivée :
+L'état global du système est géré par le capteur `router_level`, qui contrôle tous les régulateurs. Quand `router_level` est à 0, tous les régulateurs doivent être éteints, et quand il est à 100, tous les régulateurs doivent être au maximum. Pour les systèmes avec un seul régulateur, le niveau du régulateur reflète généralement le `router_level`, mais ils restent séparés car `router_level` est utilisé pour les indicateurs LED et la logique de comptage d'énergie.
+
+Voici un exemple d'implémentation d'un régulateur (extrait de [regulator_triac.yaml](https://github.com/XavierBerger/Solar-Router-for-ESPHome/blob/main/solar_router/regulator_triac.yaml)) utilisant le composant `light` et sa `brightness` pour contrôler la dérivation d'énergie :
 
 ```yaml linenums="1"
 script:
-  # Apply regulation on triac using light component
+  # Appliquer la régulation sur le triac en utilisant le composant light
   - id: regulation_control
     mode: single
     then:
-      # Apply opening level on triac using light component
+      # Appliquer router_level au triac en utilisant le composant light
       - light.turn_on:
           id: dimmer_controller
           brightness: !lambda return id(regulator_opening).state/100.0;
@@ -77,20 +79,25 @@ script:
 
 !!! tip "Astuce : Voir les régulateurs déjà développés pour des exemples"
 
-Si ce nouveau compteur électrique nécessite une configuration spécifique, les paramètres requis doivent être ajoutés dans la section `substitution`.
+Vous pouvez développer un ou plusieurs régulateurs pour travailler ensemble dans le même système. Chaque régulateur doit :
+- Avoir son propre capteur de niveau allant de 0 à 100
+- Répondre aux changements du `router_level` global du système
+- Gérer sa logique de contrôle matériel spécifique
 
-Une documentation doit être ajoutée décrivant le compteur électrique et comment le configurer. Voir le chapitre [mise à jour de la documentation](#mise-a-jour-de-la-documentation) ci-dessous.
+Si ce nouveau compteur de puissance nécessite une configuration spécifique, les paramètres requis doivent être ajoutés dans la section `substitution`.
 
-## Mise à jour de la **Documentation**
+Une documentation doit être ajoutée décrivant le compteur de puissance et comment le configurer. Voir le chapitre [mettre à jour la documentation](#mettre-à-jour-la-documentation) ci-dessous.
 
-La documentation est rédigée en utilisant [mkdocs](https://www.mkdocs.org/) et [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
+## Mettre à jour la **Documentation**
+
+La documentation est écrite en utilisant [mkdocs](https://www.mkdocs.org/) et [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
 
 Pour installer `mkdocs`, vous devez installer [Python](https://python.org) puis :
 
-- Créer un environnement virtuel (voir [documentation Python](https://docs.python.org/3/library/venv.html)).
-- Installer le module requis avec la commande suivante `pip install -r requirements.txt`.
+- Créer un environnement virtuel (voir la [documentation Python](https://docs.python.org/3/library/venv.html)).
+- Installer les modules requis avec la commande suivante `pip install -r requirements.txt`.
 
-La documentation est stockée dans le répertoire `docs`. En anglais dans le répertoire `en` etn en français dans le répertoir `fr`. Pour voir vos modifications en temps réel dans votre navigateur, exécutez la commande `mkdocs serve` et naviguez sur [http://127.0.0.1:8000](http://127.0.0.1:8000)[6].
+La documentation est stockée dans le répertoire `docs`. Pour voir vos modifications en temps réel dans votre navigateur, exécutez la commande `mkdocs serve` et naviguez sur [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
 !!! note "Mise à jour du Changelog"
     Le Changelog n'est disponible que dans la [documentation](https://xavierberger.github.io/Solar-Router-for-ESPHome/changelog/) officiellement publiée.  
@@ -100,6 +107,6 @@ La documentation est stockée dans le répertoire `docs`. En anglais dans le ré
     Les versions sont basées sur les tags.  
     Les lignes ajoutées dans le changelog sont basées sur les *messages de commit de fusion*.
 
-    Le script `tools\update_documentation.sh` est conçu pour mettre à jour `changelog.md`, générer et publier la documentation `mkdocs` sur [github pages](https://xavierberger.github.io/Solar-Router-for-ESPHome/).  
+    Le script `tools\update_documentation.sh` est conçu pour mettre à jour `changelog.md`, générer et publier la documentation `mkdocs` sur les [pages github](https://xavierberger.github.io/Solar-Router-for-ESPHome/).  
     **Le script de mise à jour de la documentation est destiné à être utilisé uniquement par le mainteneur du dépôt.**
 

--- a/solar_router/energy_counter_theorical.yaml
+++ b/solar_router/energy_counter_theorical.yaml
@@ -20,7 +20,7 @@ script:
     mode: single
     then:
       - lambda: |-
-          double diverted_energy = id(load_power).state*id(regulator_opening).state / 100;
+          double diverted_energy = id(load_power).state*id(router_level).state / 100;
           if (id(consumption).state >= diverted_energy or isnan(id(consumption).state)) 
           {
               // Therorical energy diverted is consumed (or we don't know the consumption)

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -41,7 +41,9 @@ number:
     mode: slider
     on_value:
       then:
-        - script.execute: regulation_control
+        - number.set_value:
+            id: regulator_opening
+            value: !lambda return id(router_level).state;
         - if:
             condition:
               number.in_range:
@@ -58,6 +60,18 @@ number:
                     - switch.is_on: activate
                   then:
                     - light.turn_on: green_led
+  - platform: template
+    name: "Regulator Opening"
+    id: regulator_opening
+    min_value: 0
+    max_value: 100
+    step: 1
+    unit_of_measurement: "%"
+    optimistic: True
+    mode: slider
+    on_value:
+      then:
+        - script.execute: regulation_control
 
   # Define the reactivity of router level
   - platform: template

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -69,7 +69,7 @@ number:
     unit_of_measurement: "%"
     optimistic: True
     mode: slider
-    internal: True
+    internal: ${hide_regulators}
     on_value:
       then:
         - script.execute: regulation_control

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -41,7 +41,7 @@ number:
     mode: slider
     on_value:
       then:
-        - number.set_value:
+        - number.set:
             id: regulator_opening
             value: !lambda return id(router_level).state;
         - if:

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -69,6 +69,7 @@ number:
     unit_of_measurement: "%"
     optimistic: True
     mode: slider
+    internal: True
     on_value:
       then:
         - script.execute: regulation_control

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -26,8 +26,8 @@ switch:
 number:
   # Router level from 0 to 100
   # This value serves two purposes:
-  # 1. When solar routing is disabled: Acts as a manual control to set the regulator opening level
-  # 2. When solar routing is enabled: Automatically updated to reflect the current regulator opening level
+  # 1. When solar routing is disabled: Acts as a manual control to set the router level
+  # 2. When solar routing is enabled: Automatically updated to reflect the current router level
   #    Note: Manual adjustments via slider while routing is enabled are not recommended as they will be
   #          immediately overridden by the solar router's automatic control
   - platform: template

--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -18,22 +18,21 @@ switch:
     on_turn_off:
       then:
         - light.turn_off: green_led
-        - number.to_min: regulator_opening
+        - number.to_min: router_level
         - lambda: |- 
             id(real_power).publish_state(NAN);
             id(power_meter_activated) = 0;
 
 number:
-  # Report or define regulator opening value
-  # If solar routing is not enabled, this value define the level of regulator opening
-  # If solar routing is enabled, this value is automatically updated and reflect the level
-  #   of regulator opening defined by the solar router
-  #   Moving the slider will have an impact on the solar energy diverted and will
-  #   immadiatelly be corrected by the solar router. It is advised to not use the slider
-  #   when the router is activated.
+  # Router level from 0 to 100
+  # This value serves two purposes:
+  # 1. When solar routing is disabled: Acts as a manual control to set the regulator opening level
+  # 2. When solar routing is enabled: Automatically updated to reflect the current regulator opening level
+  #    Note: Manual adjustments via slider while routing is enabled are not recommended as they will be
+  #          immediately overridden by the solar router's automatic control
   - platform: template
-    name: "Regulator Opening"
-    id: regulator_opening
+    name: "Router Level"
+    id: router_level
     min_value: 0
     max_value: 100
     step: 1
@@ -46,7 +45,7 @@ number:
         - if:
             condition:
               number.in_range:
-                id: regulator_opening
+                id: router_level
                 above: 1
             then:
               - light.turn_on:
@@ -60,7 +59,7 @@ number:
                   then:
                     - light.turn_on: green_led
 
-  # Define the reactivity of regulator opening
+  # Define the reactivity of router level
   - platform: template
     name: "Reactivity"
     id: reactivity
@@ -95,22 +94,21 @@ number:
 
 script:
   # Manage energy regulation
-  # Calculate the delta of percentage to apply to the regulator opening status to go closer to the
+  # Calculate the delta of percentage to apply to the router level status to go closer to the
   # objective. Closer we are to the objective smaller are the steps. Reactivity parameter is
   # doing a ponderation on this parameter to avoid resonance effects.
   - id: energy_regulation
     mode: single
     then:
-      # Define the opening level of regulator based on power measured and grid exchange target
+      # Define the reouter level based on power measured and grid exchange target
       # The value of regulator is a precentage and is then limited to the range 0 100
       - lambda: |-
           if (isnan(id(real_power).state) or id(safety_limit)){
             // If we can have information about grid exchange or if safety_limit is active, do not divert any energy
-            id(regulator_opening).publish_state(0);
+            id(router_level).publish_state(0);
             return;
           }
           double delta = -1*(id(real_power).state-id(target_grid_exchange).state)*id(reactivity).state/1000;
-          double regulator_status = id(regulator_opening).state + delta;
-          regulator_status = std::max(0.0, std::min(100.0, regulator_status));
-          id(regulator_opening).publish_state(regulator_status);
-
+          double new_router_level = id(router_level).state + delta;
+          new_router_level = std::max(0.0, std::min(100.0, new_router_level));
+          id(router_level).publish_state(new_router_level);

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -13,6 +13,8 @@ substitutions:
   # By default led are pin control is not inverted
   green_led_inverted: "False"
   yellow_led_inverted: "False"
+  # By default regulators are hidden
+  hide_regulators: "True"
 
 # Component managing time.
 # If activate switch is ON, power measurment and energy regulation are performed every secondes

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -27,7 +27,7 @@ switch:
             id(energy_divertion).turn_off();
 
   # Define if energy has to be diverted or not.
-  # Reset counter, manage regulator opening (0 or 100) and manage LEDs
+  # Reset counter, manage router level (0 or 100) and manage LEDs
   - platform: template
     name: "Energy divertion"
     id: energy_divertion
@@ -35,7 +35,7 @@ switch:
     on_turn_on:
       then:
         - lambda: |-
-            id(regulator_opening).publish_state(100);
+            id(router_level).publish_state(100);
             id(start_tempo_counter).publish_state(NAN);
             id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
@@ -45,7 +45,7 @@ switch:
     on_turn_off:
       then:
         - lambda: |-
-            id(regulator_opening).publish_state(0);
+            id(router_level).publish_state(0);
             id(start_tempo_counter).publish_state(NAN);
             id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
@@ -57,11 +57,16 @@ switch:
               - light.turn_on: green_led
 
 number:
-  # Regulator opening from 0 to 100
+  # Router level 0 OR 100
+  # This value serves two purposes:
+  # 1. When solar routing is disabled: Acts as a manual control to set the regulator opening level
+  # 2. When solar routing is enabled: Automatically updated to reflect the current regulator opening level
+  #    Note: Manual adjustments via slider while routing is enabled are not recommended as they will be
+  #          immediately overridden by the solar router's automatic control
   - platform: template
-    id: regulator_opening
-    name: "Regulator opening"
-    step: 1
+    id: router_level
+    name: "Router Level"
+    step: 100
     min_value: 0
     initial_value: 0
     max_value: 100

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -43,8 +43,8 @@ switch:
 number:
   # Router level 0 OR 100
   # This value serves two purposes:
-  # 1. When solar routing is disabled: Acts as a manual control to set the regulator opening level
-  # 2. When solar routing is enabled: Automatically updated to reflect the current regulator opening level
+  # 1. When solar routing is disabled: Acts as a manual control to set the router level
+  # 2. When solar routing is enabled: Automatically updated to reflect the current router level
   #    Note: Manual adjustments via slider while routing is enabled are not recommended as they will be
   #          immediately overridden by the solar router's automatic control
   - platform: template

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -24,7 +24,7 @@ switch:
             id(power_meter_activated) = 0;
             id(start_tempo_counter).publish_state(NAN);
             id(stop_tempo_counter).publish_state(NAN);
-            id(energy_divertion).turn_off();
+            id(router_level).publish_state(0);
 
   # Define if energy has to be diverted or not.
   # Reset counter, manage router level (0 or 100) and manage LEDs
@@ -32,29 +32,13 @@ switch:
     name: "Energy divertion"
     id: energy_divertion
     optimistic: True
+    internal: ${hide_regulators}
     on_turn_on:
       then:
-        - lambda: |-
-            id(router_level).publish_state(100);
-            id(start_tempo_counter).publish_state(NAN);
-            id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
-        - light.turn_on:
-            id: green_led
-            effect: blink
     on_turn_off:
       then:
-        - lambda: |-
-            id(router_level).publish_state(0);
-            id(start_tempo_counter).publish_state(NAN);
-            id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
-        - light.turn_off: green_led
-        - if:
-            condition:
-              - switch.is_on: activate
-            then:
-              - light.turn_on: green_led
 
 number:
   # Router level 0 OR 100
@@ -70,9 +54,34 @@ number:
     min_value: 0
     initial_value: 0
     max_value: 100
-    internal: True
     unit_of_measurement: "%"
     optimistic: True
+    on_value:
+      then:
+        - if:
+            condition:
+              number.in_range:
+                id: router_level
+                above: 1
+            then:
+              - switch.turn_on: energy_divertion
+              - lambda: |-
+                  id(start_tempo_counter).publish_state(NAN);
+                  id(stop_tempo_counter).publish_state(NAN);
+              - light.turn_on:
+                  id: green_led
+                  effect: blink
+            else:
+              - switch.turn_off: energy_divertion
+              - lambda: |-
+                  id(start_tempo_counter).publish_state(NAN);
+                  id(stop_tempo_counter).publish_state(NAN);
+              - light.turn_off: green_led
+              - if:
+                  condition:
+                    - switch.is_on: activate
+                  then:
+                    - light.turn_on: green_led
   
   # Define the power level to start divertion
   - platform: template
@@ -155,13 +164,13 @@ script:
       - lambda: |-
           if (isnan(id(real_power).state) or id(safety_limit)){
             // If we can have information about grid exchange or if safety_limit is active, do not divert any energy
-            id(energy_divertion).turn_off();
+            id(router_level).publish_state(0);
             return;
           }
           if (id(real_power).state < -id(start_power_level).state) 
           {
             // Energy divertion is needed
-            if ( id(energy_divertion).state ){
+            if ( id(router_level).state >= 100 ){
               // Energy divertion is already done
               id(start_tempo_counter).publish_state(NAN);
               return;
@@ -175,7 +184,7 @@ script:
             id(start_tempo_counter).publish_state(id(start_tempo_counter).state - 1);
             if (id(start_tempo_counter).state <= 0)
             {
-              id(energy_divertion).turn_on();
+              id(router_level).publish_state(100);
               id(start_tempo_counter).publish_state(NAN);
             }
             return;
@@ -183,7 +192,7 @@ script:
           if (id(real_power).state > -id(stop_power_level).state) 
           {
             // If energy divertion need to be stopped
-            if (not id(energy_divertion).state){
+            if (id(router_level).state <= 0){
               // Energy divertion is already stopped
               id(stop_tempo_counter).publish_state(NAN);
               return;
@@ -197,7 +206,7 @@ script:
             id(stop_tempo_counter).publish_state(id(stop_tempo_counter).state - 1);
             if (id(stop_tempo_counter).state <= 0)
             {
-              id(energy_divertion).turn_off();
+              id(router_level).publish_state(0);
               id(stop_tempo_counter).publish_state(NAN);
             }
             return;


### PR DESCRIPTION
As discussed [here](https://github.com/XavierBerger/Solar-Router-for-ESPHome/pull/51#issuecomment-2627767637), this PR changes the naming convention:

- Introduction of `router_level` which represents the overall system routing level (from 0-100)
- All LED and Energy Counter logic are now computed from `router_level` and not `regulator_opening`. This allows changing `regulator_opening` (if exposed to HA) without impacting LED or energy counter
- On systems with dimmers like TRIAC or SSR:
  - `regulator_opening` is equal to `router_level`
  - Both are needed because `regulator_opening` controls the regulator (TRIAC or SSR)
  - `regulator_opening` is not exposed to HA (with `internal: True`) as it's a copy of `router_level`
  - Could add `expose_regulators` substitution to allow exposing it if desired
- On systems with ON/OFF regulation:
  - `regulator_opening` is not needed, only `router_level` is set
  - Updated step to 100 so `router_level` is either 0 or 100
- Updated docs to reflect all of this


TODO:
- ~~Test (this PR is not tested)~~
- ~~Update comments & docs~~
- Update screenshots in docs