### PR TITLE
New Engine: Regulator with Bypass Relay

### DIFF
--- a/docs/en/engine_regulator_with_bypass.md
+++ b/docs/en/engine_regulator_with_bypass.md
@@ -1,0 +1,76 @@
+# Regulator with Bypass Engine
+
+This package implements the engine of the solar router which determines when and how much energy has to be diverted to the load, with a bypass function for maximum efficiency.
+
+When the regulator is intensively used for an extended period, the regulator will tends to overheat. This engine is designed to avoid this issue by activating a bypass relay and turning off the regulator when the regulator is opened at 100% for an extended period. To avoid flickering, the bypass relay is activated only when the regulator is opened at 100% for a number of consecutive regulation.
+
+**Regulator with Bypass engine** calls every second the power meter to get the actual energy exchanged with the grid. If energy produced is greater than energy consumed and exceeds the defined exchange target, the engine will determine the **percentage of regulator opening** and adjusts it dynamically to reach the target. When the regulator reaches 100% for an extended period, the bypass relay is activated for maximum efficiency.
+
+Engine's automatic regulation can be activated or deactivated with the activation switch.
+
+## How to wire the bypass relay
+
+- Live on the Bypass Relay Common (COM) and on the Relay to the Live Input of the Regulator
+- Normally Closed (NC) floating
+- Normally Open (NO) of the Relay to the Load Output of the Regulator (or directly to the Load)
+
+!!! Danger "Follow the wiring instructions"
+    Do not plug the Regulator Live Input to the Normally Closed (NC) of the relay ! Your load would be de-energized while switching the relay, potentially creating arcs inside the relay.
+    More info in this [discussion](https://github.com/XavierBerger/Solar-Router-for-ESPHome/pull/51#issuecomment-2625724543).
+
+## User feedback LEDS
+
+The yellow LED is reflecting the network connection:
+
+- ***OFF*** : solar router is not connected to power supply.
+- ***ON*** : solar router is connected to the network.
+- ***blink*** : solar router is not connected to the network and is trying to reconnect.
+- ***fast blink*** : An error occurs during the reading of energy exchanged with the grid.
+
+The green LED is reflecting the actual configuration of regulation:
+
+- ***OFF*** : automatic regulation is deactivated.
+- ***ON*** : automatic regulation is active and is not diverting energy to the load.
+- ***blink*** : solar router is currently sending energy to the load.
+
+## Router Level vs Regulator Opening
+
+The solar router uses three distinct but related level controls:
+
+- **Router Level**: This is the main system-wide control (0-100%) that represents the overall routing state. It controls the LED indicators and energy counter logic. When automatic regulation is enabled, this level is dynamically adjusted based on power measurements.
+
+- **Regulator Opening**: This represents the actual opening level (0-100%) of the physical regulator. By default, it mirrors the router level since there is only one regulator. While it can be controlled independently, changes to regulator_opening alone won't affect the router_level or trigger LED state changes.
+
+- **Bypass Relay**: This represents the actual state (ON/OFF) of the physical bypass relay. When the Regulation is enabled, this relay automatically turns on after the duration `bypass_timer_threshold` defined bellow. When the Regulation is disabled, you can manually trigger this relay to fully energized your load, LEDs and Energy Counter (if enabled) will not be triggered. You can also set the *Router Level* to 100, this will enable the relay, fully energized your load, trigger LEDs and Energy Counter.
+
+The regulator opening entity is hidden from Home Assistant by default. To expose it, change the `hide_regulators` settings as shown below.
+
+Note: It's recommended to adjust the *Router Level* rather than *Regulator Opening* or *Bypass Relay* directly, as this ensures proper system feedback through LEDs and energy monitoring. Use *Regulator Opening* or *Bypass Relay* directly, after disabling *Solar Routing* only if you want to energize your load without LEDs Feedback or energy monitoring 
+
+## Configuration
+
+To use this package, add the following lines to your configuration file:
+
+```yaml linenums="1"
+packages:
+  engine_regulator_with_bypass:
+    url: https://github.com/XavierBerger/Solar-Router-for-ESPHome/
+    file: solar_router/engine_regulator_with_bypass.yaml
+```
+When this package is used it is required to define the following parameters in the `substitution` section as shown in the example below:
+
+```yaml linenums="1"
+substitutions:
+  # LEDs -------------------------------------------------------------------------
+  # Green LED is reflecting regulation status
+  # Yellow LED is reflecting power meter status
+  green_led_pin: GPIO19
+  yellow_led_pin: GPIO18
+  # (Optional) Expose regulator opening to HA (hidden by default)
+  hide_regulators: "False"
+  # Bypass parameters ----------------------------------------------------------
+  bypass_timer_threshold: "30"  # Number of consecutive regulations at 100% before activating bypass
+```
+
+!!! tip "Adjusting bypass_timer_threshold"
+    The `bypass_timer_threshold` determines how many consecutive regulations at 100% are needed before activating the bypass relay. A lower value will make the bypass more reactive but might cause more frequent switching (flickering). Because there's roughly 1 regulation per second, `bypass_timer_threshold` can be approximated as the time in second with the regulator at 100% before which the the bypass relay is activated.

--- a/docs/en/regulator_mecanical_relay.md
+++ b/docs/en/regulator_mecanical_relay.md
@@ -18,16 +18,16 @@ To use this package, add the following lines to your configuration file:
 
 ```yaml linenums="1"
 packages:
-  regulator:
+  relay_regulator:
     url: https://github.com/XavierBerger/Solar-Router-for-ESPHome/
     file: solar_router/regulator_mecanical_relay.yaml
 ```
 
-This package require the definition of pin connected to the gate of the relay : `regulator_gate_pin`
+This package require the definition of pin connected to the gate of the relay : `relay_regulator_gate_pin`
 
 ```yaml linenums="1"
 substitutions:
   # Regulator configuration ------------------------------------------------------
   # Define GPIO pin connected to the relay gate.
-  regulator_gate_pin: GPIO22
+  relay_regulator_gate_pin: GPIO22
 ```

--- a/docs/fr/engine_regulator_with_bypass.md
+++ b/docs/fr/engine_regulator_with_bypass.md
@@ -1,0 +1,77 @@
+# Régulateur avec Bypass
+
+Ce package implémente le moteur du routeur solaire qui détermine quand et quelle quantité d'énergie doit être déviée vers la charge, avec une fonction de bypass pour une efficacité maximale.
+
+Lorsque le régulateur est utilisé intensivement pendant une période prolongée, il aura tendance à surchauffer. Ce moteur est conçu pour éviter ce problème en activant un relais de bypass et en éteignant le régulateur lorsque celui-ci est ouvert à 100% pendant une période prolongée. Pour éviter le scintillement, le relais de bypass n'est activé que lorsque le régulateur est ouvert à 100% pendant un nombre consécutif de régulations.
+
+Le **régulateur avec bypass** interroge chaque seconde le compteur d'énergie pour obtenir l'énergie réelle échangée avec le réseau. Si l'énergie produite est supérieure à l'énergie consommée et dépasse l'objectif d'échange défini, le moteur déterminera le **pourcentage d'ouverture du régulateur** et l'ajustera dynamiquement pour atteindre l'objectif. Lorsque le régulateur atteint 100% pendant une période prolongée, le relais de bypass est activé pour une efficacité maximale.
+
+La régulation automatique du moteur peut être activée ou désactivée avec l'interrupteur d'activation.
+
+## Comment câbler le relais de bypass
+
+- Phase sur le Commun (COM) du relais de bypass et sur le relais vers l'entrée Phase du régulateur
+- Normalement Fermé (NC) flottant
+- Normalement Ouvert (NO) du relais vers la sortie Charge du régulateur (ou directement vers la charge)
+
+!!! Danger "Suivez les instructions de câblage"
+    Ne branchez pas l'entrée Phase du régulateur au Normalement Fermé (NC) du relais ! Votre charge serait mise hors tension lors de la commutation du relais, créant potentiellement des arcs à l'intérieur du relais.
+    Plus d'informations dans cette [discussion](https://github.com/XavierBerger/Solar-Router-for-ESPHome/pull/51#issuecomment-2625724543).
+
+## LEDs de retour utilisateur
+
+La LED jaune reflète la connexion réseau :
+
+- ***ÉTEINTE*** : le routeur solaire n'est pas alimenté.
+- ***ALLUMÉE*** : le routeur solaire est connecté au réseau.
+- ***clignotement*** : le routeur solaire n'est pas connecté au réseau et tente de se reconnecter.
+- ***clignotement rapide*** : Une erreur s'est produite lors de la lecture de l'énergie échangée avec le réseau.
+
+La LED verte reflète la configuration actuelle de la régulation :
+
+- ***ÉTEINTE*** : la régulation automatique est désactivée.
+- ***ALLUMÉE*** : la régulation automatique est active et ne dévie pas d'énergie vers la charge.
+- ***clignotement*** : le routeur solaire envoie actuellement de l'énergie vers la charge.
+
+## Niveau du Routeur vs Ouverture du Régulateur
+
+Le routeur solaire utilise trois contrôles de niveau distincts mais liés :
+
+- **Niveau du Routeur** : C'est le contrôle principal du système (0-100%) qui représente l'état global du routage. Il contrôle les indicateurs LED et la logique du compteur d'énergie. Lorsque la régulation automatique est activée, ce niveau est ajusté dynamiquement en fonction des mesures de puissance.
+
+- **Ouverture du Régulateur** : Cela représente le niveau d'ouverture réel (0-100%) du régulateur physique. Par défaut, il reflète le niveau du routeur puisqu'il n'y a qu'un seul régulateur. Bien qu'il puisse être contrôlé indépendamment, les changements de regulator_opening seuls n'affecteront pas le router_level ni ne déclencheront de changements d'état des LED.
+
+- **Relais de Bypass** : Cela représente l'état réel (ON/OFF) du relais de bypass physique. Lorsque la régulation est activée, ce relais s'active automatiquement après la durée `bypass_timer_threshold` définie ci-dessous. Lorsque la régulation est désactivée, vous pouvez déclencher manuellement ce relais pour alimenter complètement votre charge, les LED et le compteur d'énergie (si activé) ne seront pas déclenchés. Vous pouvez également régler le *Niveau du Routeur* à 100, cela activera le relais, alimentera complètement votre charge, déclenchera les LED et le compteur d'énergie.
+
+L'entité d'ouverture du régulateur est masquée de Home Assistant par défaut. Pour l'exposer, modifiez les paramètres `hide_regulators` comme indiqué ci-dessous.
+
+Note : Il est recommandé d'ajuster le *Niveau du Routeur* plutôt que l'*Ouverture du Régulateur* ou le *Relais de Bypass* directement, car cela assure un retour système approprié via les LED et la surveillance de l'énergie. Utilisez l'*Ouverture du Régulateur* ou le *Relais de Bypass* directement, après avoir désactivé le *Routage Solaire* uniquement si vous voulez alimenter votre charge sans retour des LED ou surveillance de l'énergie.
+
+## Configuration
+
+Pour utiliser ce package, ajoutez les lignes suivantes à votre fichier de configuration :
+
+```yaml linenums="1"
+packages:
+  engine_regulator_with_bypass:
+    url: https://github.com/XavierBerger/Solar-Router-for-ESPHome/
+    file: solar_router/engine_regulator_with_bypass.yaml
+```
+
+Lorsque ce package est utilisé, il est nécessaire de définir les paramètres suivants dans la section `substitution` comme montré dans l'exemple ci-dessous :
+
+```yaml linenums="1"
+substitutions:
+  # LEDs -------------------------------------------------------------------------
+  # La LED verte reflète l'état de la régulation
+  # La LED jaune reflète l'état du compteur d'énergie
+  green_led_pin: GPIO19
+  yellow_led_pin: GPIO18
+  # (Optionnel) Expose l'ouverture du régulateur à HA (masqué par défaut)
+  hide_regulators: "False"
+  # Paramètres de bypass ------------------------------------------------------
+  bypass_timer_threshold: "30"  # Nombre de régulations consécutives à 100% avant d'activer le bypass
+```
+
+!!! tip "Ajustement du bypass_timer_threshold"
+    Le `bypass_timer_threshold` détermine combien de régulations consécutives à 100% sont nécessaires avant d'activer le relais de bypass. Une valeur plus basse rendra le bypass plus réactif mais pourrait causer des commutations plus fréquentes (scintillement). Comme il y a environ 1 régulation par seconde, `bypass_timer_threshold` peut être approximé comme le temps en secondes avec le régulateur à 100% avant que le relais de bypass ne soit activé.

--- a/docs/fr/regulator_mecanical_relay.md
+++ b/docs/fr/regulator_mecanical_relay.md
@@ -18,16 +18,16 @@ Pour utiliser ce package, ajoutez les lignes suivantes à votre fichier de confi
 
 ```yaml linenums="1"
 packages:
-  regulator:
+  relay_regulator:
     url: https://github.com/XavierBerger/Solar-Router-for-ESPHome/
     file: solar_router/regulator_mecanical_relay.yaml
 ```
 
-Ce package nécessite la définition de la broche connectée à la porte du relais : `regulator_gate_pin`
+Ce package nécessite la définition de la broche connectée à la porte du relais : `relay_regulator_gate_pin`
 
 ```yaml linenums="1"
 substitutions:
   # Regulator configuration ------------------------------------------------------
   # Define GPIO pin connected to the relay gate.
-  regulator_gate_pin: GPIO22
+  relay_regulator_gate_pin: GPIO22
 ```

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -36,10 +36,10 @@ switch:
     internal: ${hide_regulators}
     on_turn_on:
       then:
-        - script.execute: regulation_control
+        - script.execute: relay_regulation_control
     on_turn_off:
       then:
-        - script.execute: regulation_control
+        - script.execute: relay_regulation_control
 
 number:
   # Router level 0 OR 100

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -1,6 +1,16 @@
 # ----------------------------------------------------------------------------------------------------
 # User interaction
 # ----------------------------------------------------------------------------------------------------
+globals:
+  # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
+  # When regulator is at 100% and delta is still positive, this counter is incremented
+  # When counter reach bypass_timer_threshold, bypass relay is activated
+  # Counter is reset to 0 when regulator is not at 100% or when delta is negative
+  - id: full_power_timer
+    type: int
+    restore_value: no
+    initial_value: '0'
+
 <<: !include engine_common.yaml
 
 switch:
@@ -135,16 +145,6 @@ number:
     initial_value: 0
     unit_of_measurement: "W"
     step: 1
-
-globals:
-  # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
-  # When regulator is at 100% and delta is still positive, this counter is incremented
-  # When counter reach bypass_timer_threshold, bypass relay is activated
-  # Counter is reset to 0 when regulator is not at 100% or when delta is negative
-  - id: full_power_timer
-    type: int
-    restore_value: no
-    initial_value: '0'
 
 # ----------------------------------------------------------------------------------------------------
 # Define scripts for power collection or energy regulation

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -1,16 +1,6 @@
 # ----------------------------------------------------------------------------------------------------
 # User interaction
 # ----------------------------------------------------------------------------------------------------
-globals:
-  # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
-  # When regulator is at 100% and delta is still positive, this counter is incremented
-  # When counter reach bypass_timer_threshold, bypass relay is activated
-  # Counter is reset to 0 when regulator is not at 100% or when delta is negative
-  - id: full_power_timer
-    type: int
-    restore_value: no
-    initial_value: '0'
-
 <<: !include engine_common.yaml
 
 switch:
@@ -29,6 +19,7 @@ switch:
       then:
         - light.turn_off: green_led
         - number.to_min: router_level
+        - number.to_max: full_power_timer
         - lambda: |- 
             id(real_power).publish_state(NAN);
             id(consumption).publish_state(NAN);
@@ -67,18 +58,13 @@ number:
     mode: slider
     on_value:
       then:
-        # If regulation is OFF and router_level is set to 100, enable bypass, else set mirror regulator_opening
-        - if:
-            condition:
-              - switch.is_off: activate
-            then:
-              - if:
-                  condition:
-                    - lambda: return id(router_level) >= 100.0;
-                  then:
-                    - switch.turn_on: energy_divertion
-                  else:
-                    - lambda: id(regulator_opening).publish_state(id(router_level))
+        - lambda: |-
+            double router_level = id(router_level).state;
+            if (router_level >= 100.0 && id(full_power_timer).state >= ${bypass_timer_threshold}) {
+              id(energy_divertion).turn_on();
+            } else {
+              id(regulator_opening).publish_state(router_level);
+            }
         - if:
             condition:
               number.in_range:
@@ -110,12 +96,23 @@ number:
         - script.execute: regulation_control
         - if:
             condition:
-              - number.in_range:
-                  id: regulator_opening
-                  below: 100
+              - lambda: return id(regulator_opening).state < 100.0;
               - switch.is_on: energy_divertion
+              - lambda: return id(full_power_timer).state >= ${bypass_timer_threshold};
             then:
               - switch.turn_off: energy_divertion
+  # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
+  # When regulator is at 100% and delta is still positive, this counter is incremented
+  # When counter reach bypass_timer_threshold, bypass relay is activated
+  # Counter is reset to 0 when regulator is not at 100% or when delta is negative
+  - platfrom: template
+    id: full_power_timer
+    min_value: 0
+    max_value: ${bypass_timer_threshold}
+    step: 1
+    initial_value: 0
+    restore_value: False
+    internal: True
 
   # Define the reactivity of router level
   - platform: template
@@ -166,6 +163,7 @@ script:
             id(router_level).publish_state(0);
             id(regulator_opening).publish_state(0);
             id(energy_divertion).turn_off();
+            id(full_power_timer).set_value(0);
             return;
           }
 
@@ -174,18 +172,10 @@ script:
           // Determine the new regulator status
           double new_router_level = id(router_level).state + delta;
           new_router_level = std::max(0.0, std::min(100.0, new_router_level));
+          id(router_level).publish_state(new_router_level);
 
           if (new_router_level >= 100.0) {
-            // If at full power, start timing the bypass condition
-            if (++id(full_power_timer) >= ${bypass_timer_threshold}) {
-              id(energy_divertion).turn_on();
-            } else {
-              id(router_level).publish_state(new_router_level);
-              id(regulator_opening).publish_state(new_router_level);
-            }
+            id(full_power_timer)++;
           } else {
-            // Reset bypass timer and update regulator state
-            id(full_power_timer) = 0;
-            id(router_level).publish_state(new_router_level);
-            id(regulator_opening).publish_state(new_router_level);
+            id(full_power_timer).set_value(0);
           }

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -107,6 +107,7 @@ number:
   # Counter is reset to 0 when regulator is not at 100% or when delta is negative
   - platform: template
     id: full_power_timer
+    optimistic: True
     min_value: 0
     max_value: ${bypass_timer_threshold}
     step: 1

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -59,11 +59,10 @@ number:
     on_value:
       then:
         - lambda: |-
-            double router_level = id(router_level).state;
-            if (router_level >= 100.0 && id(full_power_timer).state >= ${bypass_timer_threshold}) {
+            if (id(router_level).state >= 100.0 && id(full_power_timer).state >= ${bypass_timer_threshold}) {
               id(energy_divertion).turn_on();
             } else {
-              id(regulator_opening).publish_state(router_level);
+              id(regulator_opening).publish_state(id(router_level).state);
             }
         - if:
             condition:
@@ -176,7 +175,7 @@ script:
           id(router_level).publish_state(new_router_level);
 
           if (new_router_level >= 100.0) {
-            id(full_power_timer).publish_state(id(full_power_timer).state + 1)
+            id(full_power_timer).publish_state(id(full_power_timer).state + 1);
           } else {
             id(full_power_timer).publish_state(0);
           }

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -105,14 +105,14 @@ number:
   # When regulator is at 100% and delta is still positive, this counter is incremented
   # When counter reach bypass_timer_threshold, bypass relay is activated
   # Counter is reset to 0 when regulator is not at 100% or when delta is negative
-  - platfrom: template
+  - platform: template
     id: full_power_timer
     min_value: 0
     max_value: ${bypass_timer_threshold}
     step: 1
     initial_value: 0
     restore_value: False
-    internal: True
+    internal: False #True
 
   # Define the reactivity of router level
   - platform: template

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -1,0 +1,191 @@
+# ----------------------------------------------------------------------------------------------------
+# User interaction
+# ----------------------------------------------------------------------------------------------------
+<<: !include engine_common.yaml
+
+switch:
+  # Define is router is active or not
+  # When switch is ON, pooling timer will trigger every seconds
+  - platform: template
+    name: "Activate Solar Routing"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    id: activate
+    on_turn_on:
+      then:
+        - light.turn_on: green_led
+        - lambda: id(power_meter_activated) = 1;
+    on_turn_off:
+      then:
+        - light.turn_off: green_led
+        - number.to_min: router_level
+        - lambda: |- 
+            id(real_power).publish_state(NAN);
+            id(consumption).publish_state(NAN);
+            id(power_meter_activated) = 0;
+  # Define the bypass relay
+  # When bypass relay is ON, the regulator opening is set to 0
+  # When bypass relay is OFF, the regulator opening is set to the value defined by the solar router
+  - platform: template
+    name: "Bypass Relay"
+    id: energy_divertion
+    optimistic: true
+    internal: ${hide_regulators}
+    on_turn_on:
+      then:
+        - script.execute: relay_regulation_control
+        - number.to_min: regulator_opening
+    on_turn_off:
+      then:
+        - script.execute: relay_regulation_control
+
+number:
+  # Router level from 0 to 100
+  # This value serves two purposes:
+  # 1. When solar routing is disabled: Acts as a manual control to set the router level
+  # 2. When solar routing is enabled: Automatically updated to reflect the current router level
+  #    Note: Manual adjustments via slider while routing is enabled are not recommended as they will be
+  #          immediately overridden by the solar router's automatic control
+  - platform: template
+    name: "Router Level"
+    id: router_level
+    min_value: 0
+    max_value: 100
+    step: 1
+    unit_of_measurement: "%"
+    optimistic: True
+    mode: slider
+    on_value:
+      then:
+        # If regulation is OFF and router_level is set to 100, enable bypass, else set mirror regulator_opening
+        - if:
+            condition:
+              - switch.is_off: activate
+            then:
+              - if:
+                  condition:
+                    - lambda: return id(router_level) >= 100.0;
+                  then:
+                    - switch.turn_on: energy_divertion
+                  else:
+                    - lambda: id(regulator_opening).publish_state(id(router_level))
+        - if:
+            condition:
+              number.in_range:
+                id: router_level
+                above: 1
+            then:
+              - light.turn_on:
+                  id: green_led
+                  effect: blink
+            else:
+              - light.turn_off: green_led
+              - if:
+                  condition:
+                    - switch.is_on: activate
+                  then:
+                    - light.turn_on: green_led
+  - platform: template
+    name: "Regulator Opening"
+    id: regulator_opening
+    min_value: 0
+    max_value: 100
+    step: 1
+    unit_of_measurement: "%"
+    optimistic: True
+    mode: slider
+    internal: ${hide_regulators}
+    on_value:
+      then:
+        - script.execute: regulation_control
+        - if:
+            condition:
+              - number.in_range:
+                  id: regulator_opening
+                  below: 100
+              - switch.is_on: energy_divertion
+            then:
+              - switch.turn_off: energy_divertion
+
+  # Define the reactivity of router level
+  - platform: template
+    name: "Reactivity"
+    id: reactivity
+    optimistic: True
+    restore_value: True
+    mode: box
+    min_value: 1
+    max_value: 100
+    initial_value: 10
+    unit_of_measurement: ""
+    step: 1
+
+  # Define the target level of grid exchange
+  #   0 : no exchange
+  #  <0 : continue the send energy to the grid
+  #  >0 : pull energy from the grid to better confort
+  - platform: template
+    name: "Target grid exchange"
+    id: target_grid_exchange
+    optimistic: True
+    restore_value: True
+    mode: box
+    min_value: -99999
+    max_value: 99999
+    initial_value: 0
+    unit_of_measurement: "W"
+    step: 1
+
+globals:
+  # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
+  # When regulator is at 100% and delta is still positive, this counter is incremented
+  # When counter reach bypass_timer_threshold, bypass relay is activated
+  # Counter is reset to 0 when regulator is not at 100% or when delta is negative
+  - id: full_power_timer
+    type: int
+    restore_value: no
+    initial_value: '0'
+
+# ----------------------------------------------------------------------------------------------------
+# Define scripts for power collection or energy regulation
+# ----------------------------------------------------------------------------------------------------
+
+script:
+  # Manage energy regulation
+  # Calculate the delta of percentage to apply to the router level status to go closer to the
+  # objective. Closer we are to the objective smaller are the steps. Reactivity parameter is
+  # doing a ponderation on this parameter to avoid resonance effects.
+  - id: energy_regulation
+    mode: single
+    then:
+      # Define the reouter level based on power measured and grid exchange target
+      # The value of regulator is a precentage and is then limited to the range 0 100
+      - lambda: |-
+          // Safety check: Disable regulation if power readings are invalid or safety is triggered
+          if (isnan(id(real_power).state) or id(safety_limit)){
+            id(router_level).publish_state(0);
+            id(regulator_opening).publish_state(0);
+            id(energy_divertion).turn_off();
+            return;
+          }
+
+          // Calculate the power difference and adjust the regulator opening percentage
+          double delta = -1*(id(real_power).state-id(target_grid_exchange).state)*id(reactivity).state/1000;
+          // Determine the new regulator status
+          double new_router_level = id(router_level).state + delta;
+          new_router_level = std::max(0.0, std::min(100.0, new_router_level));
+
+          if (new_router_level >= 100.0) {
+            // If at full power, start timing the bypass condition
+            if (++id(full_power_timer) >= ${bypass_timer_threshold}) {
+              id(energy_divertion).turn_on();
+            } else {
+              id(router_level).publish_state(new_router_level);
+              id(regulator_opening).publish_state(new_router_level);
+            }
+          } else {
+            // Reset bypass timer and update regulator state
+            id(full_power_timer) = 0;
+            id(router_level).publish_state(new_router_level);
+            id(regulator_opening).publish_state(new_router_level);
+          }

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -109,7 +109,7 @@ number:
     step: 1
     initial_value: 0
     restore_value: False
-    internal: False #True
+    internal: True
 
   # Define the reactivity of router level
   - platform: template

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -96,7 +96,7 @@ number:
         - script.execute: regulation_control
         - if:
             condition:
-              - lambda: return id(regulator_opening).state < 100.0;
+              - lambda: return id(router_level).state < 100.0;
               - switch.is_on: energy_divertion
               - lambda: return id(full_power_timer).state >= ${bypass_timer_threshold};
             then:

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -164,7 +164,7 @@ script:
             id(router_level).publish_state(0);
             id(regulator_opening).publish_state(0);
             id(energy_divertion).turn_off();
-            id(full_power_timer).set_value(0);
+            id(full_power_timer).publish_state(0);
             return;
           }
 
@@ -176,7 +176,7 @@ script:
           id(router_level).publish_state(new_router_level);
 
           if (new_router_level >= 100.0) {
-            id(full_power_timer)++;
+            id(full_power_timer).publish_state(id(full_power_timer).state + 1)
           } else {
-            id(full_power_timer).set_value(0);
+            id(full_power_timer).publish_state(0);
           }

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -63,6 +63,7 @@ number:
             if (id(router_level).state >= 100.0 && id(full_power_timer).state >= ${bypass_timer_threshold}) {
               id(energy_divertion).turn_on();
             } else {
+              id(energy_divertion).turn_off();
               id(regulator_opening).publish_state(id(router_level).state);
             }
         - if:
@@ -94,13 +95,7 @@ number:
     on_value:
       then:
         - script.execute: regulation_control
-        - if:
-            condition:
-              - lambda: return id(router_level).state < 100.0;
-              - switch.is_on: energy_divertion
-              - lambda: return id(full_power_timer).state >= ${bypass_timer_threshold};
-            then:
-              - switch.turn_off: energy_divertion
+
   # Define the number of consecutive regulations where regulator is at 100% before activating bypass relay
   # When regulator is at 100% and delta is still positive, this counter is incremented
   # When counter reach bypass_timer_threshold, bypass relay is activated

--- a/solar_router/engine_regulator_with_bypass.yaml
+++ b/solar_router/engine_regulator_with_bypass.yaml
@@ -13,6 +13,7 @@ switch:
     id: activate
     on_turn_on:
       then:
+        - number.to_min: full_power_timer
         - light.turn_on: green_led
         - lambda: id(power_meter_activated) = 1;
     on_turn_off:
@@ -30,7 +31,7 @@ switch:
   - platform: template
     name: "Bypass Relay"
     id: energy_divertion
-    optimistic: true
+    optimistic: True
     internal: ${hide_regulators}
     on_turn_on:
       then:
@@ -105,6 +106,7 @@ number:
   # When counter reach bypass_timer_threshold, bypass relay is activated
   # Counter is reset to 0 when regulator is not at 100% or when delta is negative
   - platform: template
+    name: "Full Power Timer"
     id: full_power_timer
     optimistic: True
     min_value: 0
@@ -161,8 +163,6 @@ script:
           // Safety check: Disable regulation if power readings are invalid or safety is triggered
           if (isnan(id(real_power).state) or id(safety_limit)){
             id(router_level).publish_state(0);
-            id(regulator_opening).publish_state(0);
-            id(energy_divertion).turn_off();
             id(full_power_timer).publish_state(0);
             return;
           }

--- a/solar_router/regulator_mecanical_relay.yaml
+++ b/solar_router/regulator_mecanical_relay.yaml
@@ -4,7 +4,7 @@
 
 script:
   # Apply regulation on relay
-  - id: regulation_control
+  - id: relay_regulation_control
     mode: single
     then:
       lambda: |-
@@ -26,6 +26,6 @@ output:
   - platform: gpio
     id: relay_output
     pin: 
-      number: ${regulator_gate_pin}
+      number: ${relay_regulator_gate_pin}
       inverted: true
 


### PR DESCRIPTION
Hello,

This PR fixes https://github.com/XavierBerger/Solar-Router-for-ESPHome/issues/49
This PR is a follow-up of https://github.com/XavierBerger/Solar-Router-for-ESPHome/pull/51

# Add bypass engine mode for solar router

This PR adds a new engine mode that combines the benefits of both the regular engine (smooth regulation) and the on/off engine (relay control) by automatically switching between them based on power conditions.

## Goal

Using a dimmer like a robotdyn triac allows a fine control of the load. Triac emits the most heat when they are set to 100% (when all current flows) for a sustained period of time.
This approach optimizes energy efficiency by using the relay for full power situations while maintaining smooth regulation for partial power needs.

## New files added:
- `solar_router/engine_regulator_with_bypass.yaml`: New engine implementation
- `solar_router/bypass_relay.yaml`: Bypass relay control configuration
- `docs/en/engine_regulator_with_bypass.md`: English doc of the new enegine
- `docs/fr/engine_regulator_with_bypass.md`: French doc of the new enegine translated from English with ClaudeAI

## How it works:
1. The system operates like the regular engine, using smooth regulation (0-100%)
2. When the `router_level` stays at 100% for `bypass_timer_threshold` regulations:
   - The bypass relay is activated
   - The regulator is set to 0% (in this order)
3. When power demand decreases (`router_level` < 100):
   - The regulator at the desired level
   - The bypass relay is deactivated (in this order)

## Notes:
- I applied the `regulator_opening` & `energy_divertion` logic directly to the components. Like this, it also works when solar routing is Off
- Compared to previous PR, I switched `full_power_timer` to a Number Template component. It's not exposed to HA.
- As mentioned in previous PR, in order to avoid code duplication, I had to rename `regulation_control` of the relay to `relay_ regulation_control`, and `regulator_gate_pin` of the relay to `relay_regulator_gate_pin`. Without this modification, TRIAC and Relay were sharing the same values and regulation was impossible. ⚠️ This is a breaking change ⚠️ . I updated the corresponding doc. I did not updated the PoC YAML files `esp32*.yaml`, `esp8266*.yaml` etc at the root folder of the repo as they seems already outdated.
- Tested: works great 🚀 