### PR TITLE
feat: #74 hide_leds + doc: Add `hide_regulators` documentation & Fix `relay_regulator_gate_pin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ work_in_progress.yaml
 /secrets.yaml
 /site/
 /venv/
+/.vs

--- a/docs/en/engine.md
+++ b/docs/en/engine.md
@@ -26,8 +26,10 @@ The green LED is reflecting the actual configuration of regulation:
 
 LEDs configuraton are done in engine configuration.
 
-### Hide or show regulators sensors
+### Hide or show sensors
 
 An optionnal `hide_regulators` variable allow to change regulators sensors visibility in HA (hidden by default).
+
+An optionnal `hide_leds` variable allow to change leds values visibility in HA (hidden by default).
 
 This configuraton is done in engine configuration.

--- a/docs/en/engine.md
+++ b/docs/en/engine.md
@@ -25,3 +25,9 @@ The green LED is reflecting the actual configuration of regulation:
 - ***blink*** : solar router is currently sending energy to the load.
 
 LEDs configuraton are done in engine configuration.
+
+### Hide or show regulators sensors
+
+An optionnal `hide_regulators` variable allow to change regulators sensors visibility in HA (hidden by default).
+
+This configuraton is done in engine configuration.

--- a/docs/en/engine_1dimmer.md
+++ b/docs/en/engine_1dimmer.md
@@ -33,7 +33,8 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO14
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
 
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
 

--- a/docs/en/engine_1dimmer.md
+++ b/docs/en/engine_1dimmer.md
@@ -33,8 +33,12 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO14
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
 
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example.
+* `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+* `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+* `hide_leds` allow to hide or show leds values from HA and is optionnal.
 

--- a/docs/en/engine_1dimmer_1bypass.md
+++ b/docs/en/engine_1dimmer_1bypass.md
@@ -43,8 +43,9 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
 
 !!! tip "Adjusting Bypass Tempo"
     The `Bypass Tempo` determines how many consecutive regulations at 100% are needed before activating the bypass relay. A lower value will make the bypass more reactive but might cause more frequent switching (flickering). Because there's roughly 1 regulation per second, `Bypass Tempo` can be approximated as the time in second with the regulator at 100% before which the the bypass relay is activated.

--- a/docs/en/engine_1dimmer_1bypass.md
+++ b/docs/en/engine_1dimmer_1bypass.md
@@ -43,9 +43,14 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example.
+* `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+* `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+* `hide_leds` allow to hide or show leds values from HA and is optionnal.
 
 !!! tip "Adjusting Bypass Tempo"
     The `Bypass Tempo` determines how many consecutive regulations at 100% are needed before activating the bypass relay. A lower value will make the bypass more reactive but might cause more frequent switching (flickering). Because there's roughly 1 regulation per second, `Bypass Tempo` can be approximated as the time in second with the regulator at 100% before which the the bypass relay is activated.

--- a/docs/en/engine_1switch.md
+++ b/docs/en/engine_1switch.md
@@ -43,7 +43,8 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
 
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
 

--- a/docs/en/engine_1switch.md
+++ b/docs/en/engine_1switch.md
@@ -43,8 +43,12 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
 
-When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example. `xxx_led_inverted` can define is led is active on high or low signal and is optional. `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+When this package is used it is required to define `green_led_pin` and `yellow_led_pin` in `vars` section as show in the upper example.
+* `xxx_led_inverted` can define is led is active on high or low signal and is optional.
+* `hide_regulators` allow to hide or show regulators sensors from HA and is optionnal.
+* `hide_leds` allow to hide or show leds values from HA and is optionnal.
 

--- a/docs/en/regulator_mecanical_relay.md
+++ b/docs/en/regulator_mecanical_relay.md
@@ -23,7 +23,7 @@ packages:
     files:
       - path: solar_router/regulator_mecanical_relay.yaml
         vars:
-          regulator_gate_pin: GPIO22
+          relay_regulator_gate_pin: GPIO22
 ```
 
-This package require the definition of pin connected to the gate of the relay. Set `regulator_gate_pin` into `vars` according to your hardware
+This package require the definition of pin connected to the gate of the relay. Set `relay_regulator_gate_pin` into `vars` according to your hardware

--- a/docs/fr/engine.md
+++ b/docs/fr/engine.md
@@ -26,3 +26,9 @@ La LED verte reflète la configuration actuelle de la régulation :
 - ***CLIGNOTANTE*** : le routeur solaire envoie actuellement de l'énergie à la charge.
 
 La configuration des LED est effectuée dans la configuration de l'`engine`.
+
+### Afficher ou masquer les capteurs de régulateurs
+
+Une variable optionnelle `hide_regulators` permet de changer la visibilité des capteurs de régulateurs dans HA (cachés par défaut).
+
+Cette configuration est effectuée dans la configuration de l'`engine`.

--- a/docs/fr/engine.md
+++ b/docs/fr/engine.md
@@ -27,8 +27,10 @@ La LED verte reflète la configuration actuelle de la régulation :
 
 La configuration des LED est effectuée dans la configuration de l'`engine`.
 
-### Afficher ou masquer les capteurs de régulateurs
+### Afficher ou masquer des capteurs
 
 Une variable optionnelle `hide_regulators` permet de changer la visibilité des capteurs de régulateurs dans HA (cachés par défaut).
+
+Une variable optionnelle `hide_leds` permet de changer la visibilité des valeurs de leds dans HA (cachés par défaut).
 
 Cette configuration est effectuée dans la configuration de l'`engine`.

--- a/docs/fr/engine_1dimmer.md
+++ b/docs/fr/engine_1dimmer.md
@@ -21,7 +21,8 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO14
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
 
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme mo,ntré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
 

--- a/docs/fr/engine_1dimmer.md
+++ b/docs/fr/engine_1dimmer.md
@@ -21,8 +21,13 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO14
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
 
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus.
+ * Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+ * Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
+ * Le paramètre `hide_leds` permet de définir si les valeurs des leds sont affichées dans HA. Ce paramètre est optionnel.
+
 

--- a/docs/fr/engine_1dimmer_1bypass.md
+++ b/docs/fr/engine_1dimmer_1bypass.md
@@ -44,9 +44,13 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus.
+ * Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+ * Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
+ * Le paramètre `hide_leds` permet de définir si les valeurs des leds sont affichées dans HA. Ce paramètre est optionnel.
 
 !!! tip "Ajustement du Bypass tempo"
     Le `Bypass tempo` détermine combien de régulations consécutives à 100% sont nécessaires avant d'activer le relais de bypass. Une valeur plus basse rendra le bypass plus réactif mais pourrait causer des commutations plus fréquentes (scintillement). Comme il y a environ 1 régulation par seconde, `Bypass tempo` peut être approximé comme le temps en secondes avec le régulateur à 100% avant que le relais de bypass ne soit activé.

--- a/docs/fr/engine_1dimmer_1bypass.md
+++ b/docs/fr/engine_1dimmer_1bypass.md
@@ -44,8 +44,9 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme mo,ntré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
 
 !!! tip "Ajustement du Bypass tempo"
     Le `Bypass tempo` détermine combien de régulations consécutives à 100% sont nécessaires avant d'activer le relais de bypass. Une valeur plus basse rendra le bypass plus réactif mais pourrait causer des commutations plus fréquentes (scintillement). Comme il y a environ 1 régulation par seconde, `Bypass tempo` peut être approximé comme le temps en secondes avec le régulateur à 100% avant que le relais de bypass ne soit activé.

--- a/docs/fr/engine_1switch.md
+++ b/docs/fr/engine_1switch.md
@@ -42,7 +42,8 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
+          hide_regulators: 'False'
 ```
 
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme mo,ntré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme mo,ntré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
 

--- a/docs/fr/engine_1switch.md
+++ b/docs/fr/engine_1switch.md
@@ -42,8 +42,11 @@ packages:
           green_led_inverted: 'False'
           yellow_led_pin: GPIO2
           yellow_led_inverted: 'False'
-          hide_regulators: 'False'
+          hide_regulators: 'True'
+          hide_leds: 'True'
 ```
 
-Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme mo,ntré dans l'exemple ci-dessus. Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel. Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
-
+Il est necessaire de définir `green_led_pin` et `yellow_led_pin` dans la section `vars` comme montré dans l'exemple ci-dessus.
+ * Le paramètre `xxx_led_inverted` permet de définir si la LED est active sur niveau haut ou bas. Ce paramètre est optionnel.
+ * Le paramètre `hide_regulators` permet de définir si le capteur de régulateur est affiché dans HA. Ce paramètre est optionnel.
+ * Le paramètre `hide_leds` permet de définir si les valeurs des leds sont affichées dans HA. Ce paramètre est optionnel.

--- a/docs/fr/regulator_mecanical_relay.md
+++ b/docs/fr/regulator_mecanical_relay.md
@@ -23,7 +23,7 @@ packages:
     files:
       - path: solar_router/regulator_mecanical_relay.yaml
         vars:
-          regulator_gate_pin: GPIO22
+          relay_regulator_gate_pin: GPIO22
 ```
 
 Ce package nécessite la définition de la broche connectée à la porte du relais : `relay_regulator_gate_pin`

--- a/solar_router/engine_1dimmer_1bypass.yaml
+++ b/solar_router/engine_1dimmer_1bypass.yaml
@@ -35,7 +35,7 @@ switch:
     name: "Energy divertion"
     id: energy_divertion
     optimistic: True
-    internal: true
+    internal: ${hide_regulators}
 
 binary_sensor:
   - platform: template
@@ -51,12 +51,14 @@ sensor:
     name: "Bypass tempo"
     unit_of_measurement: "s"
     update_interval: 1s
+    internal: ${hide_regulators}
 
   - platform: template
     name: "Regulator Opening"
     id: regulator_opening
     unit_of_measurement: "%"
     update_interval: 1s
+    internal: ${hide_regulators}
 
 number:
   # Router level from 0 to 100

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -15,6 +15,8 @@ substitutions:
   yellow_led_inverted: "False"
   # By default regulators are hidden
   hide_regulators: "True"
+  # By default leds are hidden
+  hide_leds: "True"
 
 # Component managing time.
 # If activate switch is ON, power measurment and energy regulation are performed every secondes
@@ -74,7 +76,7 @@ light:
   - id: yellow_led
     platform: binary
     output: yellow_led_output
-    internal: True
+    internal: ${hide_leds}
     effects:
       - strobe:
           name: blink
@@ -98,7 +100,7 @@ light:
   - id: green_led
     platform: binary
     output: green_led_output
-    internal: True
+    internal: ${hide_leds}
     effects:
       - strobe:
           name: blink

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -74,6 +74,7 @@ output:
 
 light:
   - id: yellow_led
+    name: "Yellow Led"
     platform: binary
     output: yellow_led_output
     internal: ${hide_leds}
@@ -98,6 +99,7 @@ light:
               duration: 50ms
 
   - id: green_led
+    name: "Green Led"
     platform: binary
     output: green_led_output
     internal: ${hide_leds}


### PR DESCRIPTION
Hello,

Thanks for this project.

I use it yesterday and found some issues in my esphome compulation after following the online documentation (missing consumption_sensor and yellow/green_led_pin, and have put two regulator_gate_pin instead of one relay_regulator_gate_pin and one regulator_gate_pin).

When i wanted to fix the documentation i see that the last version of this documenation is not yet online so i follow this last version and see some things to complete and fix ;)

- Replace _regulator_gate_pin_ with _relay_regulator_gate_pin_ for regulator_mecanical_relay
- Add documentation for the undocumented _hide_regulators_ var
- Fix some typo
- I also add _.vs_ directory in _.gitignore_ for VisualStudio IDE

After some test with Engine 1 x dimmer + 1 x bypass, i see that it don't use _hide_regulators_ var. So i propose to use it for:
- Bypass tempo (because it feel like under the hood processing var, but this is just a proposal)
- Regulator Opening (same as Engine 1 x dimmer)
- Energy divertion (same as Engine 1 x switch)

I also add implementation and documentation for #74 with new var _hide_leds_